### PR TITLE
chore: allow use custom http endpoint for eosApi

### DIFF
--- a/src/stories/4-RicardianContract.stories.js
+++ b/src/stories/4-RicardianContract.stories.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { withKnobs, text } from '@storybook/addon-knobs'
+import { withKnobs, text, boolean } from '@storybook/addon-knobs'
 
 import RicardianContract from '../RicardianContract'
 
@@ -10,7 +10,10 @@ export default {
 }
 
 export const ricardianContract = () => {
-  const name = text('name', 'consent2life')
+  const httpEndpoint = text('httpEndpoint', 'https://jungle.eosio.cr')
+  const contractName = text('contractName', 'consent2life')
+  const actionName = text('actionName', undefined)
+  const showClauses = boolean('showClauses', true)
 
-  return <RicardianContract name={name} url='https://jungle.bloks.io' />
+  return <RicardianContract httpEndpoint={httpEndpoint} contractName={contractName} actionName={actionName} showClauses={showClauses} url='https://jungle.bloks.io' />
 }


### PR DESCRIPTION
### What does this PR do?
- Allow use a custom endpoint for eosApi
- Handle image on error to display a default icon when original it's not available
- Avoid undefined text for title and version 
- Allow hide and show general clauses 
- Allow display all actions or only one 

### How should this be tested?
- yarn
- yarn storybook
- go to `http://localhost:9009/`
- click "RicardianContract from side menu
- change the default "Knobs"