### PR TITLE
fix(ricardian-contract): parse data according to EOSIO ricardian spec

### DIFF
--- a/src/components/RicardianContract/RicardianContract.js
+++ b/src/components/RicardianContract/RicardianContract.js
@@ -87,19 +87,16 @@ const RicardianContract = ({
 
   const formatRicardianClause = useCallback(
     (text = '') => {
-      const [_version, content1] = text.split('\ntitle: ')
+      const [_version, content1] = text.replace(/---/g, '').split('\ntitle: ')
       const version = _version.replace(/---\n/g, '')
       const [_title, content2] = (content1 || '').split('\nsummary: ')
       const [summary, _icon] = (content2 || '').split('\nicon: ')
+      const icon = _icon ? _icon.trim() : defaultIcon
 
       return (
         <Box>
           <Box className={classes.boxTitle}>
-            <img
-              alt="icon"
-              src={_icon || defaultIcon}
-              onError={useDefaultLogo}
-            />
+            <img alt="icon" src={icon} onError={useDefaultLogo} />
             <Box className={classes.boxText}>
               <Typography color="primary" variant="h4">
                 {_title}


### PR DESCRIPTION
Resolves #69 

## Problem
Ricardian contract component were not displaying the ricardian icon because of a wrong icon url

## Solution
Parse and trim unneeded data as `---` and ` `

All change made here is considering EOSIO/ricardian-spec standard which at this point is as follow:

```
---
spec_version: 0.0.0
title: Create Post
summary: Create a blog post "{{title}}" by {{author}} tagged as "{{tag}}"
icon: https://app.com/create-post.png#00506E08A55BCF269FE67F202BBC08CFF55F9E3C7CD4459ECB90205BF3C3B562
---
I, {{author}}, author of the blog post "{{title}}", certify that I am the original author of the contents of this blog post and have attributed all external sources appropriately.

{{$clauses.legalese}}
```
